### PR TITLE
Correctly translate bt148 to gross instead of net

### DIFF
--- a/app/locales/en/translation.json
+++ b/app/locales/en/translation.json
@@ -151,7 +151,7 @@
   "bt146" :"Unit price (net)",
   "bt131" :"Total price (net)",
   "bt147" :"Discount (net)",
-  "bt148" :"Net list price",
+  "bt148" :"list price (gross)",
   "bt149" :"Number of units",
   "bt150" :"Unit of measure code",
   "bt151" :"VAT",

--- a/app/locales/fr/translation.json
+++ b/app/locales/fr/translation.json
@@ -151,7 +151,7 @@
     "bt146" :"Prix unitaire net",
     "bt131" :"Prix total net",
     "bt147" :"Remise nette",
-    "bt148" :"Prix catalogue (net)",
+    "bt148" :"Prix catalogue (brut)",
     "bt149" :"Nombre d'unités",
     "bt150" :"Code de l'unité de mesure ",
     "bt151" :"TVA",


### PR DESCRIPTION
I had initially opened the program in English. I was very surprised that the field `GrossPriceProductTradePrice` was shown as a net price. After I changed the translation to German, it was then (correctly in my eyes) the gross price. Hence this pull request to correct the translations in English and French. 