### PR TITLE
Register shortcut to close app by using cmd+q

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -162,6 +162,11 @@ function registerShortcuts() {
     electronLocalShortcut.register(mainWindow, "CommandOrControl+O", () => {
         openFile();
     });
+    electronLocalShortcut.register(mainWindow, "Command+Q", () => {
+        if (process.platform === "darwin") {
+            app.quit();
+        }
+    });
 }
 
 const gotTheLock = app.requestSingleInstanceLock();


### PR DESCRIPTION
Somehow the standard shortcut for closing programs on mac 'cmd + q' does not work.