### PR TITLE
Fix missing titlebar on mac for about modal

### DIFF
--- a/app/menuConfig.js
+++ b/app/menuConfig.js
@@ -239,6 +239,12 @@ function openAboutWindow(mainWindow, app, i18n) {
   });
   newWindow.setMenuBarVisibility(false);
 
+  // this hack is necessary, because of a mac specific bug in electron: https://github.com/electron/electron/issues/27160#issuecomment-1325840197
+  if (process.platform === "darwin") {
+    newWindow.modal = false;
+    newWindow.closable = true;
+  }
+
   ipcMain.on("about-info", (event) => {
     event.sender.send("about-info", { ...aboutWindowTranslation });
   });


### PR DESCRIPTION
Closes [#88](https://github.com/ZUGFeRD/quba-viewer/issues/88)

This seems to be an unresolved issue for electron even if the issues get closed by the maintainers as seen here:
- https://github.com/electron/electron/issues/27160
- https://github.com/electron/electron/issues/40673