### PR TITLE
Add pdf fileAssociation to the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,13 @@
       "!package.json",
       "!package-lock.json"
     ],
+    "fileAssociations": [
+      {
+        "ext": "pdf",
+        "name": "PDF File",
+        "role": "Viewer"
+      }
+    ],
     "publish": [
       {
         "provider": "github",


### PR DESCRIPTION
Closes https://github.com/ZUGFeRD/quba-viewer/issues/106

This does seem to work for mac, and also for Linux (Pop!_OS 22.04) with my locally build release.

Unfortunately I do not have a Windows setup at the moment to test it on.

This can probably be extended to work for xml files, but I am not sure if thats desired.