### PR TITLE
Publish Quba to Flathub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 release
 #Electron-builder output
 /dist_electron
+.flatpak-builder
+build
+/dist

--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ structured (i.e., XML) and hybrid (Factur-X/ZUGFeRD PDF) electronic invoices.
 Documentation-wise there is a doc RE [Architecture, Development, Debugging and testing](doc/development.md) in 
 general and some Electron and E-Invoice peculiarities like [interprocess (IPC) communication, XSLT and codelists](doc/electron.md) in particular.
 
+Flatpak
+=============
+
+To build the app as a Flatpak, make sure you have `flatpak` installed: <https://flatpak.org/setup/>.
+Then, follow these steps:
+
+```shell
+# Build & Install
+cd flatpak
+flatpak-builder build org.quba_viewer.Quba.yml --install-deps-from=flathub --force-clean --user --install
+
+# Run
+flatpak run org.quba_viewer.Quba
+```
+
 History
 =============
 

--- a/flatpak/org.quba_viewer.Quba.yml
+++ b/flatpak/org.quba_viewer.Quba.yml
@@ -1,0 +1,52 @@
+# Adapted from: https://github.com/flathub/electron-sample-app/blob/c559bf20ea4dc3bb0887e0bd18d311083d49d826/flatpak/org.flathub.electron-sample-app.yml
+
+app-id: org.quba_viewer.Quba
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '23.08'
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node18
+command: run.sh
+separate-locales: false
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --filesystem=host:ro
+  - --socket=system-bus
+build-options:
+  append-path: /usr/lib/sdk/node18/bin
+  env:
+    NPM_CONFIG_LOGLEVEL: info
+modules:
+  - name: Quba
+    buildsystem: simple
+    build-options:
+      env:
+        XDG_CACHE_HOME: /run/build/Quba/flatpak-node/cache
+        npm_config_cache: /run/build/Quba/flatpak-node/npm-cache
+        npm_config_offline: 'true'
+    build-commands:
+      # Install npm dependencies
+      - npm install --offline
+      # Build the app; in this example the `dist` script
+      # in package.json runs electron-builder
+      - |
+        . ../flatpak-node/electron-builder-arch-args.sh
+        npm run dist -- $ELECTRON_BUILDER_ARCH_ARGS  --linux --dir
+      # Bundle app and dependencies
+      - cp -a release/linux*unpacked /app/main
+      # Install app wrapper
+      - install -Dm755 -t /app/bin/ ../run.sh
+    subdir: main
+    sources:
+      - type: dir
+        path: ..
+        dest: main
+      - generated-sources.json
+      # Wrapper to launch the app
+      - type: script
+        dest-filename: run.sh
+        commands:
+          - zypak-wrapper.sh /app/main/quba "$@"


### PR DESCRIPTION
We'd like to use Quba in our organization. To allow for easier deployment it'd be nice to publish Quba to Flathub.

We have supplied a Manifest file for building Quba in a flatpak, see [flatpak/org.quba_viewer.Quba.yml](https://github.com/giz-berlin/quba-viewer/blob/feat/flatpak/flatpak/org.quba_viewer.Quba.yml). The chosen app id `org.quba_viewer.Quba` is completely up for debate, if you think another name would be better.

Instructions to build it locally have been added to the README:

```shell
# Build & Install
cd flatpak
flatpak-builder build org.quba_viewer.Quba.yml --install-deps-from=flathub --force-clean --user --install

# Run
flatpak run org.quba_viewer.Quba
```

In case you're interested in publishing Quba to Flathub, we'd be willing to support you in the process.