### PR TITLE
fix some window management (for MacOS)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -654,6 +654,7 @@ async function readInstallerConfigAndPerformAutoUpdate() {
 }
 
 function openFile() {
+    if (mainWindow === null) createWindow();
     dialog
         .showOpenDialog(BrowserWindow, {
             path: "",


### PR DESCRIPTION
The following I tried to fix:
- do not use modal windows for about and manual windows on MacOS, avoid opening them twice
- also avoid a crash when closing the main window and opening a file afterwards

Related to #108 